### PR TITLE
feature/32-edit-threads

### DIFF
--- a/ForumServer/src/main/kotlin/com/example/forumserver/api/controller/ThreadController.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/api/controller/ThreadController.kt
@@ -60,4 +60,14 @@ class ThreadController(
     fun listParentableThreads(): ResponseEntity<ApiResponse<List<ThreadEntityPairProjection>>> {
         return ResponseEntity.ok(ApiResponse(data = threadMapper.listParentableThreads()))
     }
+
+    @PutMapping("/edit/{threadId}")
+    fun editThread(@RequestBody threadDTO: ThreadDTO, @PathVariable threadId: Long): ResponseEntity<ApiResponse<ThreadDTO>>{
+        return try {
+            ResponseEntity.ok(ApiResponse(data = threadMapper.editThread(threadDTO, threadId)))
+        } catch (ex: RuntimeException){
+            ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse(error = true, errorMessage = ex.message))
+        }
+    }
 }

--- a/ForumServer/src/main/kotlin/com/example/forumserver/api/dto/ThreadDTO.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/api/dto/ThreadDTO.kt
@@ -15,9 +15,10 @@ data class ThreadDTO(
     val status: String?,
     val parentThreadId: Long?,
     val description: String?,
+    val hasChildren: Boolean?
 )
 
-fun ThreadEntity.toDTO(): ThreadDTO  =
+fun ThreadEntity.toDTO(hasChildren: Boolean?): ThreadDTO  =
     ThreadDTO(
         id = this.id!!, //todo id must exist and should be hashed
         dateCreated = this.dateCreated,
@@ -29,5 +30,6 @@ fun ThreadEntity.toDTO(): ThreadDTO  =
         title = this.title,
         status = this.status,
         description = this.description,
-        parentThreadId = this.parentThread?.id
+        parentThreadId = this.parentThread?.id,
+        hasChildren = hasChildren
     )

--- a/ForumServer/src/main/kotlin/com/example/forumserver/api/mapper/ThreadMapper.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/api/mapper/ThreadMapper.kt
@@ -15,27 +15,33 @@ class ThreadMapper(
 ) {
     fun findThread(threadId: Long): ThreadDTO {
         //check permission
-
-        return threadService.findThread(threadId).toDTO()
+        val thread = threadService.findThread(threadId)
+        return thread.toDTO(threadService.hasChildren(thread))
     }
 
     fun findThreads(pageNum: Int, pageSize: Int): PageResponse<ThreadDTO> {
         val pageable = PageRequest.of(pageNum, pageSize)
-        return threadService.findParentThreads(pageable).toPageResponse { it.toDTO() }
+        return threadService.findParentThreads(pageable).toPageResponse { it.toDTO(null) }
     }
 
     fun findChildThreads(threadId: Long, pageNum: Int, pageSize: Int): PageResponse<ThreadDTO> {
         val pageable = PageRequest.of(pageNum, pageSize)
-        return threadService.findChildThreads(threadId, pageable).toPageResponse { it.toDTO() }
+        return threadService.findChildThreads(threadId, pageable).toPageResponse { it.toDTO(null) }
     }
 
     fun createThread(threadDTO: ThreadDTO): ThreadDTO? {
         //permission
 
-        return threadService.create(threadDTO).toDTO()
+        return threadService.create(threadDTO).toDTO(null)
     }
 
     fun listParentableThreads(): List<ThreadEntityPairProjection> {
         return threadService.listAllParentableThreads()
+    }
+
+    fun editThread(threadDTO: ThreadDTO, threadId: Long): ThreadDTO? {
+        //permission
+
+        return threadService.edit(threadDTO, threadId).toDTO(null)
     }
 }

--- a/ForumServer/src/main/kotlin/com/example/forumserver/core/entity/helper_class/ThreadEntity.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/core/entity/helper_class/ThreadEntity.kt
@@ -10,6 +10,8 @@ import java.time.LocalDateTime
 @Table(name = "threads", schema = "forum_post")
 data class ThreadEntity(
 
+    override val id: Long?,
+
     val title: String,
 
     val status: String?,
@@ -32,6 +34,7 @@ data class ThreadEntity(
     @JoinColumn(name = "last_modified_by")
     override val lastModifiedBy: User? = null
 ) : BaseClass(
+    id = id,
     dateCreated = dateCreated,
     lastDateModified = lastDateModified,
     createdBy = createdBy,

--- a/ForumServer/src/main/kotlin/com/example/forumserver/core/repository/ThreadRepository.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/core/repository/ThreadRepository.kt
@@ -12,12 +12,16 @@ import org.springframework.stereotype.Repository
 interface ThreadRepository : JpaRepository<ThreadEntity, Long> {
     fun findByParentThread(thread: ThreadEntity, pageable: Pageable): Page<ThreadEntity>
 
+    @Query("select (count(t) > 0) from ThreadEntity t where t.parentThread = ?1")
+    fun threadHasChildren(parentThread: ThreadEntity): Boolean
 
+    /***
+     * Returns all projections with id - title pairs where thread does not have parent
+     ***/
     @Query("select t from ThreadEntity t where t.parentThread is null")
     fun findByParentThreadNull(): List<ThreadEntityPairProjection>
 
     fun findByParentThreadNull(pageable: Pageable): Page<ThreadEntity>
-
 
     fun existsByTitleIgnoreCase(title: String): Boolean
 

--- a/forum-client/src/api-interfaces/dtos/thread.dto.ts
+++ b/forum-client/src/api-interfaces/dtos/thread.dto.ts
@@ -10,4 +10,5 @@ export interface ThreadDTO{
     status?: String,
     parentThreadId?: number,
     description?: String,
+    hasChildren?: boolean,
 }

--- a/forum-client/src/components/app/app.routes.ts
+++ b/forum-client/src/components/app/app.routes.ts
@@ -22,9 +22,10 @@ export const routes: Routes = [
   {
     path: "threads",
     children: [
-      { path: '', component: ThreadBodyComponent},
+      { path: 'edit/:threadId', component: ThreadCreationBodyComponent},
       { path: 'create', component: ThreadCreationBodyComponent},
       { path: ':threadId', component: ThreadBodyComponent},
+      { path: '', component: ThreadBodyComponent},
     ]
   },
   {

--- a/forum-client/src/components/body-components/thread-body/thread-body.component.css
+++ b/forum-client/src/components/body-components/thread-body/thread-body.component.css
@@ -25,7 +25,9 @@
 }
 
 .action-button{
-  color: #e0e3e2;
+  height: 32px;
+  width: 32px;
+  color: #3bda50;
   transition: color 0.2s ease;
 }
 

--- a/forum-client/src/components/body-components/thread-body/thread-body.component.html
+++ b/forum-client/src/components/body-components/thread-body/thread-body.component.html
@@ -4,7 +4,7 @@
     <span class="spacer"></span>
     <a 
       class="action-button"
-      href="/threads/create"
+      [routerLink]="['/threads/create']"
       matIconButton
       matTooltip="Create new thread"
       aria-label="Button that redirects to create thread page">
@@ -56,6 +56,17 @@
     <ng-container matColumnDef="createdBy">
       <th mat-header-cell *matHeaderCellDef> Created By </th>
       <td mat-cell *matCellDef="let thread"> {{thread.createdByUsername}} </td>
+    </ng-container>
+
+    <!-- Actions Column -->
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef> Actions </th>
+      <td mat-cell *matCellDef="let thread">
+          <a class="action-button" [routerLink]="[`/threads/edit/${thread.id}`]" matIconButton matTooltip="Edit thread"
+            aria-label="Button that redirects to edit thread page">
+            <mat-icon>edit</mat-icon>
+          </a>
+      </td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/forum-client/src/components/body-components/thread-body/thread-body.component.ts
+++ b/forum-client/src/components/body-components/thread-body/thread-body.component.ts
@@ -14,7 +14,7 @@ import { MatToolbar, MatToolbarModule } from '@angular/material/toolbar';
 import { MatCardModule } from '@angular/material/card';
 import { ThreadDTO } from '../../../api-interfaces/dtos/thread.dto';
 import { Pageable } from '../../../api-interfaces/dtos/pageable.dts';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
@@ -31,7 +31,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MatToolbar,
     MatCardModule,
     MatToolbarModule,
-    MatTooltipModule],
+    MatTooltipModule,
+    RouterLink
+  ],
   templateUrl: './thread-body.component.html',
   styleUrl: './thread-body.component.css'
 })
@@ -41,7 +43,7 @@ export class ThreadBodyComponent  implements OnInit{
   private readonly activatedRoute = inject(ActivatedRoute)
   private readonly threadService = inject(ThreadService);
 
-  displayedColumns: string[] = ['title', 'description', 'status', 'createdBy'];
+  displayedColumns: string[] = ['title', 'description', 'status', 'createdBy', 'actions'];
   dataSource = new MatTableDataSource<ThreadDTO>();
 
   searchTerm = '';

--- a/forum-client/src/components/body-components/thread-creation-body/thread-creation-body.component.html
+++ b/forum-client/src/components/body-components/thread-creation-body/thread-creation-body.component.html
@@ -1,6 +1,6 @@
 
 <mat-card class="create-thread-container">
-  <h2 class="title">Create New Thread</h2>
+  <h2 class="title">{{ threadId ? 'Edit Thread' : 'Create New Thread'}}</h2>
 
   <form [formGroup]="threadForm" (ngSubmit)="onSubmit()">
 
@@ -41,9 +41,11 @@
       <mat-select formControlName="parentThreadId">
         <mat-option [value]="null">None</mat-option>
         @for (thread of parentThreads; track $index) {
+        @if(thread.id != loadedThread?.id){
         <mat-option [value]="thread.id">
           {{ thread.title }}
         </mat-option>
+        }
         }
 
       </mat-select>
@@ -52,7 +54,7 @@
     <!-- Submit -->
     <div class="action-buttons">
       <button mat-raised-button color="primary" type="submit" [disabled]="threadForm.invalid || loading">
-        Create Thread
+        {{ threadId ? 'Edit Thread' : 'Create Thread'}}
       </button>
 
       @if (loading) {

--- a/forum-client/src/components/reusables/navigation-menu/navigation-menu.component.html
+++ b/forum-client/src/components/reusables/navigation-menu/navigation-menu.component.html
@@ -1,11 +1,11 @@
 <mat-toolbar>
   @if (!authenticated()) {
-    <span><a href="/register" mat-raised-button>Create account</a></span>
+    <span><a [routerLink] ="['/register']" mat-raised-button>Create account</a></span>
   }
-  <span><a href="/threads" mat-raised-button>Forum</a></span> 
-  <span><a href="#" mat-raised-button>Information</a></span>
+  <span><a [routerLink] ="['/threads']" mat-raised-button>Forum</a></span> 
+  <span><a routerLink ="#" mat-raised-button>Information</a></span>
   @if (!authenticated()) {
-    <span><a href="/login" mat-raised-button>Log in</a></span>
+    <span><a [routerLink] ="['/login']" mat-raised-button>Log in</a></span>
   }
   @else{
     <span><a (click)="logOut()" mat-raised-button>Log out</a></span>

--- a/forum-client/src/components/reusables/navigation-menu/navigation-menu.component.ts
+++ b/forum-client/src/components/reusables/navigation-menu/navigation-menu.component.ts
@@ -2,12 +2,12 @@ import { Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import {MatToolbarModule} from '@angular/material/toolbar';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ConfirmationDialogComponent } from '../confirmation-dialog/confirmation-dialog.component';
 
 @Component({
   selector: 'navigation-menu',
-  imports: [MatToolbarModule, MatButtonModule],
+  imports: [MatToolbarModule, MatButtonModule, RouterLink],
   templateUrl: './navigation-menu.component.html',
   styleUrl: './navigation-menu.component.css'
 })

--- a/forum-client/src/services/thread.service.ts
+++ b/forum-client/src/services/thread.service.ts
@@ -35,7 +35,12 @@ export class ThreadService {
         return this.http.get<ApiResponse<ThreadPairProjection[]>>(`${this.url}/parentable`)
     }
 
-    createThread(threadDTO: ThreadDTO): Observable<ApiResponse<ThreadDTO>> {
-        return this.http.post<ApiResponse<ThreadDTO>>(`${this.url}/create`, threadDTO)
+    createThread(threadDTO: ThreadDTO, threadId?: string | null): Observable<ApiResponse<ThreadDTO>> {
+        if (threadId) {
+            return this.http.put<ApiResponse<ThreadDTO>>(`${this.url}/edit/${threadId}`, threadDTO)
+        } else {
+            return this.http.post<ApiResponse<ThreadDTO>>(`${this.url}/create`, threadDTO)
+        }
+        
     }
 }


### PR DESCRIPTION
32.Edit threads functionality
- Updated app.routes for the edit page
- Fixed navigation menu to use routerLink so it does not refresh the whole page
- Updated threadDTO to include hasChildren field (FE, BE)
- Thread service (FE) modified createThread so it can be used for creating new thread or updating existing one
- Updated button's style in thread body component
- Added column in thread body table and fixed href to routerLink
- Updated thread creation body component to be used for creation (previous use) and editing existing thread
- Thread Controller have new post endpoint for edithing threads
- ThreadEntity added id so it can be accessed when editing
- Thread Mapper have new edit method and added hasChildren for findThread
- Thread Repository have new threadHasChildren method for checking
- Thread Service
    * hasChildren method to connect to repository
    * Modified invalidThreadFields to not check for createdBy when is creating thread
    * edit Thread new method