### PR TITLE
feature/34-edit-for-post

### DIFF
--- a/ForumServer/src/main/kotlin/com/example/forumserver/api/controller/PostController.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/api/controller/PostController.kt
@@ -7,7 +7,10 @@ import com.example.forumserver.api.response.ApiResponse
 import com.example.forumserver.api.response.PageResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -17,6 +20,15 @@ import org.springframework.web.bind.annotation.RestController
 class PostController(
     private val postMapper: PostMapper
 ) {
+    @GetMapping("{postId}")
+    fun getPost(@PathVariable postId: Long): ResponseEntity<ApiResponse<PostDTO>>{
+        return try {
+            ResponseEntity.ok(ApiResponse(data = postMapper.getPost(postId)))
+        }catch (ex: RuntimeException){
+            ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse(error = true, errorMessage = ex.message))
+        }
+    }
 
     //todo make it get
     @PostMapping
@@ -29,6 +41,16 @@ class PostController(
         return try {
             ResponseEntity.ok(ApiResponse(data = postMapper.createPost(request)))
         } catch (ex: RuntimeException){
+            ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse(error = true, errorMessage = ex.message))
+        }
+    }
+
+    @PutMapping("/edit/{postId}")
+    fun editPost(@RequestBody postBody: PostDTO, @PathVariable postId: Long): ResponseEntity<ApiResponse<PostDTO>>{
+        return try {
+            ResponseEntity.ok(ApiResponse(data = postMapper.editPost(postBody, postId)))
+        }catch (ex: RuntimeException){
             ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse(error = true, errorMessage = ex.message))
         }

--- a/ForumServer/src/main/kotlin/com/example/forumserver/api/mapper/PostMapper.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/api/mapper/PostMapper.kt
@@ -32,5 +32,18 @@ class PostMapper(
         return postService.createPost(request).toDTO()
     }
 
+    fun getPost(postId: Long): PostDTO {
+        //permission
+
+        return postService.findPost(postId).toDTO()
+    }
+
+    fun editPost(postBody: PostDTO, postId: Long): PostDTO? {
+        //permission
+
+        val oldPost = postService.findPost(postId)
+        return postService.editPost(postBody, oldPost).toDTO()
+    }
+
 
 }

--- a/ForumServer/src/main/kotlin/com/example/forumserver/core/service/PostService.kt
+++ b/ForumServer/src/main/kotlin/com/example/forumserver/core/service/PostService.kt
@@ -45,4 +45,20 @@ class PostService(
 
         return postRepository.save(postEntity)
     }
+
+    fun editPost(postBody: PostDTO, oldPost: PostEntity): PostEntity {
+        if(postBody.html.isBlank()){
+            throw RuntimeException("Content provided is blank exception!")
+        }
+
+        val lastModifiedBy = postBody.lastModifiedBy?.let { userDetailsService.findUserById(it) }
+
+        val editedPost = oldPost.copy(
+            html = postBody.html,
+            lastDateModified = LocalDateTime.now(),
+            lastModifiedBy = lastModifiedBy
+        )
+
+        return postRepository.save(editedPost)
+    }
 }

--- a/forum-client/src/api-interfaces/dtos/post.dto.ts
+++ b/forum-client/src/api-interfaces/dtos/post.dto.ts
@@ -6,6 +6,6 @@ export interface PostDTO {
     createdBy?: number,
     createdByUsername?: string,
     lastDateModified?: Date,
-    lastModifiedBy?: string,
+    lastModifiedBy?: number,
     threadId?: number
 } 

--- a/forum-client/src/components/body-components/post-body/post-body.component.css
+++ b/forum-client/src/components/body-components/post-body/post-body.component.css
@@ -60,3 +60,7 @@
     justify-content: space-between;
     align-items: center;
   }
+
+  .post-actions{
+    float: right;
+  }

--- a/forum-client/src/components/body-components/post-body/post-body.component.html
+++ b/forum-client/src/components/body-components/post-body/post-body.component.html
@@ -8,7 +8,7 @@
     <mat-toolbar color="primary" class="toolbar">
         <span>{{ thread?.title}}</span>
         <span class="spacer"></span>
-        <a class="action-button post-button" [routerLink]="[`add`]" matIconButton matTooltip="Add post"
+        <a class="action-button" [routerLink]="[`add`]" matIconButton matTooltip="Add post"
             aria-label="Button that redirects to add post page">
             <mat-icon>add_comment</mat-icon>
         </a>
@@ -33,8 +33,28 @@
         <tr>
             <td class="user-cell">{{ post.createdBy }}</td>
             <td>
-                <div [innerHTML]="post.html"></div>
-                <div> {{ post.dateCreated }} </div>
+                <!-- Actions -->
+                <div class="post-container">
+                    <div class="post-actions">
+                        <button mat-raised-button [matMenuTriggerFor]="menu">
+                            <mat-icon>menu</mat-icon>
+                        </button>
+                        <mat-menu #menu="matMenu">
+                            <button mat-button class="action-button" 
+                            [routerLink]="[`edit/${post.id}`]" 
+                            matTooltip="Add post"
+                            aria-label="Button that redirects to edit post page">
+                                <mat-icon>edit</mat-icon>
+                            </button>
+                        </mat-menu>
+                    </div>
+                    <!-- Content -->
+                    <div [innerHTML]="post.html"></div>
+                    <!-- Date created -->
+                    <div> {{ post.dateCreated }} </div>
+        
+        
+                </div>
             </td>
         </tr>
         }

--- a/forum-client/src/components/body-components/post-body/post-body.component.ts
+++ b/forum-client/src/components/body-components/post-body/post-body.component.ts
@@ -10,6 +10,8 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatCardModule } from '@angular/material/card';
 import { ThreadDTO } from '../../../api-interfaces/dtos/thread.dto';
 import { ThreadService } from '../../../services/thread.service';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'app-post-body',
@@ -18,7 +20,9 @@ import { ThreadService } from '../../../services/thread.service';
     RouterLink, 
     MatIconModule, 
     MatToolbarModule,
-    MatCardModule
+    MatCardModule,
+    MatMenuModule,
+    MatButtonModule,
   ],
   templateUrl: './post-body.component.html',
   styleUrl: './post-body.component.css'

--- a/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.css
+++ b/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.css
@@ -24,5 +24,6 @@
 .action-buttons {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 16px;
 }

--- a/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.html
+++ b/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.html
@@ -26,11 +26,14 @@
             }
         </mat-form-field>
 
-        <!-- Submit -->
+    <!-- Submit -->
     <div class="action-buttons">
       <button mat-raised-button color="primary" type="submit" [disabled]="postForm.invalid || loading">
         {{ postId ? 'Edit Thread' : 'Create Thread'}}
       </button>
+      <!-- Cancel -->
+      <!-- type="button" prevents submition on the form-->
+      <button type="button" mat-button color="primary" (click)="cancel()" >Cancel</button>
 
     @if (loading) {
     <mat-progress-spinner diameter="24" mode="indeterminate" class="loading-spinner"></mat-progress-spinner>

--- a/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.ts
+++ b/forum-client/src/components/body-components/post-creation-body/post-creation-body.component.ts
@@ -36,6 +36,7 @@ export class PostCreationBodyComponent implements OnInit{
   private readonly postService = inject(PostService)
 
   postId: string | null = null
+  post: PostDTO | null = null
   thread: ThreadDTO | null = null
   loading = false
 
@@ -45,6 +46,20 @@ export class PostCreationBodyComponent implements OnInit{
 
   ngOnInit(): void {
     this.postId = this.activatedRoute.snapshot.paramMap.get("postId")
+    if(this.postId){
+      this.loading = true
+      this.postService.getPost(this.postId).subscribe({
+        next: result => {
+          this.post = result.data
+          this.postForm.patchValue(this.post)
+          this.loading = false
+        },
+        error: error => {
+          console.log(error);
+          this.loading = false
+        }
+      })
+    }
 
     const threadId = this.activatedRoute.snapshot.paramMap.get('threadId')
     if(threadId){
@@ -69,7 +84,8 @@ export class PostCreationBodyComponent implements OnInit{
     const postData: PostDTO = {
       html: this.postForm.value.html,
       threadId: this.thread?.id,
-      createdBy: 1
+      createdBy: 1, //todo
+      lastModifiedBy: 1 //todo
     }
     
     this.postService.createPost(postData, this.postId).subscribe({
@@ -83,6 +99,10 @@ export class PostCreationBodyComponent implements OnInit{
       }
     })
     
+  }
+
+  cancel() {
+    this.router.navigate([`threads/posts/${this.thread?.id}`])
   }
 
 }

--- a/forum-client/src/services/post.service.ts
+++ b/forum-client/src/services/post.service.ts
@@ -19,4 +19,8 @@ export class PostService{
             return this.http.post<ApiResponse<PostDTO>>(`${this.url}/create`, postDTO)
         }
     }
+
+    getPost(postId: string): Observable<ApiResponse<PostDTO>> {
+      return this.http.get<ApiResponse<PostDTO>>(`${this.url}/${[postId]}`)
+    }
 }


### PR DESCRIPTION
34. Make edit for posts
- PostDTO (FE) lastModifiedBy type changed to number because of the id being number not string
- PostService.ts added get post method api
- Post-body component css added class for float right actions
- Post-body component html added action buttons for every post and slight restructuring
- Post body component ts added imports for matMenu and matButton
- Post-creation css action buttons moved to right side
- Post creation body html added cancel button to return to the thread posts
- Post creation body ts 
    * If post is edited it will be loaded
    * cancel method to cancel editing or add new post
- PostController 
    * Added getPost endpoint
    * Added editPost endpoint
- Post mapper added 
    * Added getPost method
    * Added editPost method
- Post Service
    * added getPost method
    * added editPost method